### PR TITLE
Update draco3d version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "bluebird": "^3.5.1",
     "cesium": "^1.39.0",
-    "draco3d": "^1.2.4",
+    "draco3d": "^1.2.6",
     "fs-extra": "^4.0.2",
     "jimp": "^0.2.28",
     "mime": "^2.0.3",


### PR DESCRIPTION
- This fixes an issue raised in https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/353
by @shehzan10.
- Debug_checks were turned on and the check was wrong in an older version
of the JavaScript encoder.